### PR TITLE
chore: volat dev-preflight.ps1 primo z Taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,5 +11,5 @@ tasks:
     cmds:
       - powershell -Command "[Console]::Write([char]27 + ']0;dev' + [char]7)"
       - powershell -Command "Clear-Host"
-      - pwsh -NoProfile "E:\vs\Scripts_Projects\PowershellScripts\checkout-and-pull-main.ps1"
+      - pwsh -NoProfile "E:\vs\Scripts_Projects\PowershellScripts\dev-preflight.ps1" -TaskName dev
       - dotnet run -c Debug


### PR DESCRIPTION
Vetev vytvorena Claude Code. Task dev nyni vola sdileny dev-preflight.ps1 (sync master/main + kontrola nepushnutych vetvi a otevrenych PR) pred samotnym spustenim.