### PR TITLE
chore: bump verze SunamoCl na 26.7.11.1

### DIFF
--- a/SunamoCl/SunamoCl.csproj
+++ b/SunamoCl/SunamoCl.csproj
@@ -6,7 +6,7 @@
     <PackRelease>true</PackRelease>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
-    <Version>26.5.18.8</Version>
+    <Version>26.7.11.1</Version>
     <PackageIcon>_.png</PackageIcon>
     <PackageTags>console</PackageTags>
     <Authors>www.sunamo.cz</Authors>


### PR DESCRIPTION
Bump verze pro publikaci textoveho filtru v pickeru akci (PR #7). Vetev vytvorena Claude Code.